### PR TITLE
Dev polymode approach for gams-mode

### DIFF
--- a/gams-mode.el
+++ b/gams-mode.el
@@ -51,7 +51,8 @@
 (eval-and-compile
   (require 'easymenu)
   (require 'align)
-  (require 'org))
+  (require 'org)
+  (require 'polymode))
 
 (defsubst gams-oddp (x)
   "Return t if X is odd."
@@ -17774,6 +17775,34 @@ problems."
   (let ((version-string
          (format "GAMS mode version %s" gams-mode-version)))
     (message "%s" version-string)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;     Polymode
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-hostmode poly-gams-hostmode
+  :mode 'gams-mode)
+
+(define-innermode poly-gams-yaml-innermode
+  :mode 'yaml-mode
+  :head-matcher ".?o?n?embeddedcode.* connect:$"
+  :tail-matcher ".*embeddedcode.*$"
+  :head-mode 'host
+  :tail-mode 'host)
+
+(define-innermode poly-gams-python-innermode
+  :mode 'python-mode
+  :head-matcher ".?o?n?embeddedcode.* python:$"
+  :tail-matcher ".*embeddedcode.*$"
+  :head-mode 'host
+  :tail-mode 'host)
+
+(define-polymode poly-gams-mode
+  :hostmode 'poly-gams-hostmode
+  :innermodes '(poly-gams-yaml-innermode
+		poly-gams-python-innermode))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
Hi Shiro,

This allows polymode to work well with gams-mode.

What I have not managed to do is to make it load when a gms file is loaded. If I use
`(add-to-list 'auto-mode-alist '("\\.gms\\'" . poly-gams-mode))`
it does not load any mode when opening a gms file. So for now I just open a gms file, then it is loaded in gams-mode. Then, if it has some embedded code in it I change the mode manually to poly-gams-mode and it works. If you know how to solve this issue, it would be great.

Best,
Christophe